### PR TITLE
fix: add new size to logs files in config

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,14 +7,14 @@ config :logger, :console, level: :info
 config :logger, :ecto,
   level: :info,
   path: Path.absname("logs/prod/ecto.log"),
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 52_428_800, keep: 5}
 
 config :logger, :error,
   path: Path.absname("logs/prod/error.log"),
-  rotate: %{max_bytes: 52_428_800, keep: 19}
+  rotate: %{max_bytes: 52_428_800, keep: 5}
 
 config :logger, :account,
   level: :info,
   path: Path.absname("logs/prod/account.log"),
-  rotate: %{max_bytes: 52_428_800, keep: 19},
+  rotate: %{max_bytes: 52_428_800, keep: 5},
   metadata_filter: [fetcher: :account]


### PR DESCRIPTION
## Motivation

We need to add other an lower size to logs files, so we can prevent error in backend container from Docker.

## Checklist for your Pull Request (PR)

  - [ ] I added an entry to `CHANGELOG.md` with this PR
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [ ] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [ ] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [ ] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
